### PR TITLE
Fix toast subscription effect dependencies

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -170,7 +170,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [setState])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent the toast hook from resubscribing to the global listener on every state update by scoping the effect to the stable state setter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddd55dc52883239352906db2a7fd01