### PR TITLE
Refine workspace dashboard layout

### DIFF
--- a/app/workspace/layout.tsx
+++ b/app/workspace/layout.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react"
 import { KpiStrip } from "@/components/workspace/kpi-strip"
 import { PipelineSummary } from "@/components/workspace/pipeline-summary"
 import { ActivityPanel } from "@/components/workspace/activity-panel"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 interface WorkspaceLayoutProps {
   children: ReactNode
@@ -14,26 +15,15 @@ interface WorkspaceLayoutProps {
 
 export default function WorkspaceLayout({ children, crm, insights, modal }: WorkspaceLayoutProps) {
   return (
-    <div className="space-y-12">
-      <section className="rounded-3xl border border-border/40 bg-gradient-to-br from-card/80 via-card/60 to-card/30 px-8 py-10 text-foreground shadow-lg">
-        <div className="mx-auto flex max-w-5xl flex-col gap-6 md:flex-row md:items-center md:justify-between">
+    <div className="mx-auto w-full max-w-6xl space-y-12 px-6 pb-16">
+      <section className="rounded-3xl border border-border/40 bg-gradient-to-br from-card via-card/60 to-card/30 px-8 py-10 text-foreground shadow-sm">
+        <div className="flex flex-col gap-6">
           <div className="space-y-3">
             <p className="text-sm font-medium uppercase tracking-[0.3em] text-chart-2">Workspace</p>
             <h1 className="font-serif text-4xl font-semibold sm:text-5xl">Orquesta tu operación comercial</h1>
-            <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
-              Supervisa KPIs, mantén sincronizado el pipeline y revisa la actividad en vivo desde un hub diseñado para la
-              toma de decisiones.
+            <p className="max-w-3xl text-sm text-muted-foreground sm:text-base">
+              Supervisa KPIs, mantén sincronizado el pipeline y revisa la actividad en vivo desde un hub diseñado para la toma de decisiones.
             </p>
-          </div>
-          <div className="grid gap-3 text-sm text-muted-foreground">
-            <div>
-              <span className="font-semibold text-foreground">Actualización en vivo</span>
-              <p>Los cambios en el CRM, calendario y actividad se reflejan al instante gracias a react server actions.</p>
-            </div>
-            <div>
-              <span className="font-semibold text-foreground">Atajos</span>
-              <p>Selecciona un negocio del pipeline para ver detalles o crea uno nuevo desde la tarjeta lateral.</p>
-            </div>
           </div>
         </div>
       </section>
@@ -42,12 +32,13 @@ export default function WorkspaceLayout({ children, crm, insights, modal }: Work
         <KpiStrip />
       </Suspense>
 
-      <div className="grid gap-8 xl:grid-cols-[ minmax(0,2fr)_minmax(320px,1fr) ]">
-        <div className="space-y-8">
+      <div className="grid gap-12 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
+        <div className="space-y-12">
           {children}
           {crm}
         </div>
         <aside className="space-y-6">
+          <InsightsCard />
           <Suspense fallback={<PipelineSkeleton />}>
             <PipelineSummary />
           </Suspense>
@@ -63,13 +54,35 @@ export default function WorkspaceLayout({ children, crm, insights, modal }: Work
   )
 }
 
+function InsightsCard() {
+  return (
+    <Card className="rounded-2xl border border-border/40 bg-card/60">
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base font-semibold text-foreground">Centro de control</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 p-6 pt-0 text-sm text-muted-foreground">
+        <div>
+          <p className="font-semibold text-foreground">Actualización en vivo</p>
+          <p className="mt-1">
+            Los cambios en el CRM, calendario y actividad se reflejan al instante gracias a react server actions.
+          </p>
+        </div>
+        <div className="border-t border-border/40 pt-4">
+          <p className="font-semibold text-foreground">Atajos</p>
+          <p className="mt-1">Selecciona un negocio del pipeline para ver detalles o crea uno nuevo desde la tarjeta lateral.</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 function KpiSkeleton() {
   return (
-    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
       {Array.from({ length: 3 }).map((_, index) => (
         <div
           key={index}
-          className="h-28 rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm animate-pulse"
+          className="min-h-[8rem] rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm animate-pulse"
         />
       ))}
     </div>
@@ -81,5 +94,5 @@ function PipelineSkeleton() {
 }
 
 function ActivitySkeleton() {
-  return <div className="h-72 rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm animate-pulse" />
+  return <div className="h-80 rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm animate-pulse" />
 }

--- a/components/workspace/activity-panel.tsx
+++ b/components/workspace/activity-panel.tsx
@@ -9,15 +9,15 @@ export async function ActivityPanel() {
 
   return (
     <Card className="rounded-2xl border border-border/40 bg-card/60">
-      <CardHeader>
+      <CardHeader className="pb-3">
         <CardTitle className="font-serif text-2xl text-foreground">Actividad en tiempo real</CardTitle>
         <CardDescription className="text-sm text-muted-foreground">
           Seguimos los movimientos más recientes del equipo y los mostramos al instante mediante streaming.
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="p-6 pt-0">
         <Suspense fallback={<p className="text-sm text-muted-foreground">Iniciando stream...</p>}>
-          <LiveActivityStream initialActivities={activities.slice(0, 12)} />
+          <LiveActivityStream initialActivities={activities.slice(0, 20)} />
         </Suspense>
       </CardContent>
     </Card>

--- a/components/workspace/kpi-strip.tsx
+++ b/components/workspace/kpi-strip.tsx
@@ -24,20 +24,33 @@ const TREND_STYLES: Record<string, { icon: ReactNode; tone: string; label: strin
   },
 }
 
+const KPI_ACCENTS: Record<string, string> = {
+  Ingresos: "border-chart-1/40 bg-chart-1/10",
+  "Negocios Activos": "border-chart-2/40 bg-chart-2/10",
+  "Tasa de Conversión": "border-chart-3/40 bg-chart-3/10",
+  "Tamaño Promedio": "border-chart-4/40 bg-chart-4/10",
+  "Valor del Pipeline": "border-chart-5/40 bg-chart-5/10",
+  "Puntuación NPS": "border-amber-400/40 bg-amber-400/10",
+}
+
 export async function KpiStrip() {
   const kpis = await getKPIs()
 
   return (
-    <section aria-label="Indicadores clave" className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+    <section aria-label="Indicadores clave" className="grid gap-4 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
       {kpis.map((kpi) => {
         const trend = TREND_STYLES[kpi.trend ?? "neutral"] ?? TREND_STYLES.neutral
         const numericValue = typeof kpi.value === "number" ? kpi.value : undefined
+        const accent = KPI_ACCENTS[kpi.label] ?? "border-border/40 bg-card/60"
 
         return (
-          <Card key={kpi.label} className="relative overflow-hidden rounded-2xl border border-border/40 bg-card/60">
-            <CardContent className="space-y-4 p-6">
+          <Card
+            key={kpi.label}
+            className={cn("relative h-full min-h-[8rem] overflow-hidden rounded-2xl border bg-card py-0", accent)}
+          >
+            <CardContent className="flex h-full flex-col justify-between gap-6 p-6">
               <header className="space-y-2">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-muted-foreground/90">
                   {kpi.label}
                 </p>
                 <p className="font-serif text-3xl font-semibold text-foreground">
@@ -47,7 +60,11 @@ export async function KpiStrip() {
 
               {typeof kpi.change === "number" && (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <span className={cn("flex items-center gap-1 font-medium", trend.tone)} aria-label={trend.label}>
+                  <span
+                    className={cn("flex items-center gap-1 font-medium", trend.tone)}
+                    aria-label={trend.label}
+                    role="status"
+                  >
                     {trend.icon}
                     {kpi.change > 0 ? "+" : ""}
                     {kpi.change}%

--- a/components/workspace/live-activity-stream.tsx
+++ b/components/workspace/live-activity-stream.tsx
@@ -11,6 +11,13 @@ interface LiveActivityStreamProps {
   initialActivities: Activity[]
 }
 
+const ACTIVITY_LABELS: Record<Activity["type"], string> = {
+  deal: "Actividad de negocio",
+  meeting: "Actividad de reunión",
+  email: "Actividad de correo",
+  call: "Actividad de llamada",
+}
+
 export function LiveActivityStream({ initialActivities }: LiveActivityStreamProps) {
   const [activities, setActivities] = useState<Activity[]>(initialActivities)
 
@@ -46,41 +53,39 @@ export function LiveActivityStream({ initialActivities }: LiveActivityStreamProp
   }, [])
 
   return (
-    <ul className="space-y-3">
-      {activities.map((activity) => {
-        const meta = ACTIVITY_META[activity.type]
-        const Icon = meta.icon
+    <div className="max-h-80 overflow-y-auto rounded-2xl border border-border/30 bg-background/40 p-2">
+      <ul className="divide-y divide-border/40">
+        {activities.map((activity) => {
+          const meta = ACTIVITY_META[activity.type]
+          const Icon = meta.icon
+          const label = ACTIVITY_LABELS[activity.type]
 
-        return (
-          <li
-            key={activity.id}
-            className={cn(
-              "group relative overflow-hidden rounded-2xl border border-border/40 bg-background/60 p-4 shadow-sm",
-              "transition-all duration-200 hover:border-chart-1/40 hover:bg-background/80",
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <div
-                className={cn(
-                  "flex size-10 shrink-0 items-center justify-center rounded-lg bg-placeholder transition-transform duration-200",
-                  meta.calendarColor,
-                  "group-hover:scale-105",
-                )}
-                aria-hidden
-              >
-                <Icon className="size-4" />
+          return (
+            <li key={activity.id} className="group px-3 py-4 transition-colors duration-200 hover:bg-background/70">
+              <div className="flex items-start gap-3">
+                <div
+                  className={cn(
+                    "flex size-10 shrink-0 items-center justify-center rounded-lg border transition-transform duration-200",
+                    meta.calendarColor,
+                    "group-hover:scale-105",
+                  )}
+                  aria-label={label}
+                  role="img"
+                >
+                  <Icon className="size-4" aria-hidden />
+                </div>
+                <div className="min-w-0 flex-1 space-y-1">
+                  <h3 className="font-medium leading-tight text-foreground">{activity.title}</h3>
+                  <p className="text-sm text-muted-foreground">{activity.description}</p>
+                  <p className="text-xs text-muted-foreground/80">
+                    {activity.user} · {activity.timestamp}
+                  </p>
+                </div>
               </div>
-              <div className="min-w-0 flex-1 space-y-1">
-                <h3 className="font-medium leading-tight text-foreground">{activity.title}</h3>
-                <p className="text-sm text-muted-foreground">{activity.description}</p>
-                <p className="text-xs text-muted-foreground/80">
-                  {activity.user} · {activity.timestamp}
-                </p>
-              </div>
-            </div>
-          </li>
-        )}
-      )}
-    </ul>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
   )
 }

--- a/components/workspace/pipeline-summary.tsx
+++ b/components/workspace/pipeline-summary.tsx
@@ -24,22 +24,22 @@ export async function PipelineSummary() {
 
   return (
     <Card className="rounded-2xl border border-border/40 bg-card/60">
-      <CardHeader className="pb-4">
+      <CardHeader className="pb-3">
         <CardTitle className="font-serif text-2xl text-foreground">Pipeline snapshot</CardTitle>
         <CardDescription className="text-sm text-muted-foreground">
           Mide la salud de tu embudo y cuántas oportunidades hay por etapa.
         </CardDescription>
       </CardHeader>
-      <CardContent className="space-y-6">
+      <CardContent className="space-y-6 p-6 pt-0">
         <dl className="grid gap-4 sm:grid-cols-2">
           <div className="rounded-xl border border-chart-1/40 bg-chart-1/10 p-4">
-            <dt className="text-xs font-medium uppercase tracking-[0.2em] text-chart-1/80">Valor total</dt>
+            <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-chart-1/80">Valor total</dt>
             <dd className="mt-2 text-2xl font-semibold text-chart-1">
               {formatCurrency(Math.round(snapshot.totalValue))}
             </dd>
           </div>
           <div className="rounded-xl border border-chart-2/40 bg-chart-2/10 p-4">
-            <dt className="text-xs font-medium uppercase tracking-[0.2em] text-chart-2/80">Valor ponderado</dt>
+            <dt className="text-xs font-semibold uppercase tracking-[0.28em] text-chart-2/80">Valor ponderado</dt>
             <dd className="mt-2 text-2xl font-semibold text-chart-2">
               {formatCurrency(Math.round(snapshot.weightedValue))}
             </dd>
@@ -51,7 +51,7 @@ export async function PipelineSummary() {
             <Badge
               key={stage}
               variant="outline"
-              className={`rounded-full border px-3 py-1 text-xs uppercase tracking-wider ${STAGE_COLORS[stage] ?? "border-border/40 bg-background/40 text-muted-foreground"}`}
+              className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.24em] ${STAGE_COLORS[stage] ?? "border-border/40 bg-background/40 text-muted-foreground"}`}
             >
               {STAGE_LABELS[stage] ?? stage}: {count}
             </Badge>


### PR DESCRIPTION
## Summary
- redesign the workspace hero into a centered gradient header and introduce a control card for quick tips
- standardize KPI cards with responsive grid, accent colors, and accessible trend indicators
- polish the sidebar panels with consistent padding, pipeline accents, and a scrollable activity feed

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dddf25e1288323826cabf1ca42a1e8