### PR TITLE
Set aurora light effect as default mode

### DIFF
--- a/contexts/light-settings-context.tsx
+++ b/contexts/light-settings-context.tsx
@@ -4,7 +4,7 @@ import { createContext, useContext, useState, useEffect, type ReactNode } from "
 import type { LightMode, LightSettings } from "@/lib/types"
 
 const DEFAULT_SETTINGS: LightSettings = {
-  mode: "spotlight",
+  mode: "aurora",
   intensity: 0.7,
   radius: 300,
   blendMode: "screen",


### PR DESCRIPTION
## Summary
- set the light settings context default mode to aurora so visitors see the aurora effect on first load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de791d98ac83238794f39407e9047f